### PR TITLE
Fix str_replace command to handle multi-line replacements

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -1,5 +1,6 @@
 import tempfile
 from collections import defaultdict
+import re
 from pathlib import Path
 from typing import Literal, get_args
 
@@ -127,8 +128,8 @@ class OHEditor:
                 f'No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {line_numbers}. Please ensure it is unique.'
             )
 
-        # Replace old_str with new_str
-        new_file_content = file_content.replace(old_str, new_str)
+        # Replace old_str with new_str using re.sub
+        new_file_content = re.sub(re.escape(old_str), new_str, file_content, flags=re.DOTALL)
 
         # Write the new content to the file
         self.write_file(path, new_file_content)

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -1,6 +1,6 @@
+import re
 import tempfile
 from collections import defaultdict
-import re
 from pathlib import Path
 from typing import Literal, get_args
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings --ignore=oh-viewer

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = -p no:warnings --ignore=oh-viewer
+
+plugins =
+    libtmux.pytest_plugin

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-addopts = -p no:warnings --ignore=oh-viewer
-
-plugins =
-    libtmux.pytest_plugin


### PR DESCRIPTION
The `str_replace` command in `editor.py` does not correctly handle multi-line replacements with newline characters. This PR addresses this issue by using `re.sub` with `re.DOTALL` flag to enable proper multi-line text editing.